### PR TITLE
Export filter components properly

### DIFF
--- a/src/components/FilterGroup/FilterGroup.tsx
+++ b/src/components/FilterGroup/FilterGroup.tsx
@@ -45,13 +45,13 @@ export const FilterGroup: React.FC<FilterGroupProps> = ({ options, toggled, setT
 
   /* renders filters either toggled, untoggled or disabled */
   function renderFilters() {
-    return options.map((option) => {
+    return options.map((option, index) => {
       if (toggled.includes(option)) {
-        return <FilterToggle label={option} onClick={() => handleToggle(option)} toggled />;
+        return <FilterToggle label={option} onClick={() => handleToggle(option)} toggled key={index} />;
       } else if (isDisabled(option)) {
-        return <FilterToggle label={option} onClick={() => void 0} disabled={true} />;
+        return <FilterToggle label={option} onClick={() => void 0} disabled={true} key={index} />;
       }
-      return <FilterToggle label={option} onClick={() => handleToggle(option)} />;
+      return <FilterToggle label={option} onClick={() => handleToggle(option)} key={index} />;
     });
   }
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,6 +11,8 @@ import { Loading } from './Loading/Loading';
 import { Pagination } from './Pagination';
 import { Popup } from './Popup';
 import { RadioButton } from './RadioButton';
+import { FilterToggle } from './FilterToggle/FilterToggle';
+import { FilterGroup } from './FilterGroup/FilterGroup';
 
 export {
   Button,
@@ -26,5 +28,7 @@ export {
   Pagination,
   Popup,
   RadioButton,
+  FilterToggle,
+  FilterGroup,
 };
 export type { ErrorMessageProps };

--- a/src/stories/FilterGroup.stories.tsx
+++ b/src/stories/FilterGroup.stories.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import { FilterGroup } from '../components/FilterGroup/FilterGroup';
+import { FilterGroup } from '../components';
 
 export default {
   title: 'Components/FilterGroup',

--- a/src/stories/FilterToggle.stories.tsx
+++ b/src/stories/FilterToggle.stories.tsx
@@ -1,4 +1,4 @@
-import { FilterToggle } from '../components/FilterToggle/FilterToggle';
+import { FilterToggle } from '../components';
 
 export default {
   title: 'Components/FilterToggle',


### PR DESCRIPTION
# Description
Fiks som exporterer `FilterToggle` og `FilterGroup` fra indexfilen. My bad.

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
