### PR TITLE
Added type to filter buttons

### DIFF
--- a/src/components/FilterGroup/FilterGroup.tsx
+++ b/src/components/FilterGroup/FilterGroup.tsx
@@ -7,6 +7,7 @@ interface FilterGroupProps {
   toggled: string[];
   setToggled: React.Dispatch<React.SetStateAction<string[]>>;
   exclusivity?: string[][];
+  type?: 'button' | 'submit' | 'reset' | undefined;
 }
 
 const StyledDiv = styled.div`
@@ -23,7 +24,13 @@ const StyledDiv = styled.div`
  * @param setToggled setter for toggled state
  * @param exclusivity is a list of string[] where the the sublists contain mutually exclusive options
  */
-export const FilterGroup: React.FC<FilterGroupProps> = ({ options, toggled, setToggled, exclusivity }) => {
+export const FilterGroup: React.FC<FilterGroupProps> = ({
+  type = 'button',
+  options,
+  toggled,
+  setToggled,
+  exclusivity,
+}) => {
   function isDisabled(option: string) {
     if (exclusivity) {
       return exclusivity
@@ -47,11 +54,11 @@ export const FilterGroup: React.FC<FilterGroupProps> = ({ options, toggled, setT
   function renderFilters() {
     return options.map((option, index) => {
       if (toggled.includes(option)) {
-        return <FilterToggle label={option} onClick={() => handleToggle(option)} toggled key={index} />;
+        return <FilterToggle type={type} label={option} onClick={() => handleToggle(option)} toggled key={index} />;
       } else if (isDisabled(option)) {
-        return <FilterToggle label={option} onClick={() => void 0} disabled={true} key={index} />;
+        return <FilterToggle type={type} label={option} onClick={() => void 0} disabled={true} key={index} />;
       }
-      return <FilterToggle label={option} onClick={() => handleToggle(option)} key={index} />;
+      return <FilterToggle type={type} label={option} onClick={() => handleToggle(option)} key={index} />;
     });
   }
 

--- a/src/components/FilterToggle/FilterToggle.tsx
+++ b/src/components/FilterToggle/FilterToggle.tsx
@@ -5,12 +5,19 @@ interface FilterToggleProps {
   label: string;
   toggled?: boolean;
   disabled?: boolean;
+  type?: 'button' | 'submit' | 'reset' | undefined;
   onClick: () => void;
 }
 
-export const FilterToggle: React.FC<FilterToggleProps> = ({ label, toggled = false, disabled, onClick }) => {
+export const FilterToggle: React.FC<FilterToggleProps> = ({
+  label,
+  toggled = false,
+  disabled,
+  onClick,
+  type = 'button',
+}) => {
   return (
-    <button className={`filterToggle ${toggled && 'toggled'} ${disabled && 'disabled'}`} onClick={onClick}>
+    <button type={type} className={`filterToggle ${toggled && 'toggled'} ${disabled && 'disabled'}`} onClick={onClick}>
       {toggled && <Check className="check" />}
       {label}
     </button>


### PR DESCRIPTION
HTML5 button has a default type of "submit". This results that every button inside a form will try to submit the form when pressed. This hotfix allows for assigning the type of the buttons used in filters, and makes the default behaviour as a regular button.