### PR TITLE
🐛 FIX: specify style to prevent leak

### DIFF
--- a/src/components/FilterToggle/FilterToggle.scss
+++ b/src/components/FilterToggle/FilterToggle.scss
@@ -33,7 +33,7 @@
         height: auto;
         fill: $dark-bright-blue;
 
-        :not(&.hidden) {
+        &:not(&.hidden) {
             transition: transform 0.3s, opacity 0.3s;
             opacity: 1;
             transform: translateX(0px);


### PR DESCRIPTION
Style for `filterToggle` leaket ut til alle elementer i DOMen. Stylen er nå mer spesifikk for å forhindre dette.