### PR TITLE
Bugfix/input layout shift

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "innbyggerkontakt-design-system",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": false,
   "description": "Innbyggerkontakt design system",
   "main": "./dist/index.js",

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -31,7 +31,7 @@ export interface InputProps {
 }
 
 const InputEl = styled.input`
-  margin: 0;
+  margin: 1px;
   width: 100%;
   border-radius: 3px;
   box-sizing: border-box;
@@ -45,6 +45,7 @@ const InputEl = styled.input`
   line-height: 20px;
 
   &:focus {
+    margin: 0;
     border-width: 2px;
     outline: none;
   }


### PR DESCRIPTION
# Description
Margin er brukt for å motvirke layout shifting ved økt border tykkelse.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Closes #31 
